### PR TITLE
Fix for 64 bit systems

### DIFF
--- a/src/ios/HttpRequest/HttpRequest.m
+++ b/src/ios/HttpRequest/HttpRequest.m
@@ -15,7 +15,7 @@
 {
     NSString *method = [command.arguments objectAtIndex:0];
     NSString *urlStr = [command.arguments objectAtIndex:1];
-    int argCnt = [command.arguments count];
+    NSInteger argCnt = [command.arguments count];
     
     NSURL *URL = [NSURL URLWithString:urlStr];
     R9HTTPRequest *request = [[R9HTTPRequest alloc] initWithURL:URL];


### PR DESCRIPTION
Avoid "int" on iOS and use NSInteger instead.